### PR TITLE
stop relying on current directory being in library path

### DIFF
--- a/t/_header.t
+++ b/t/_header.t
@@ -4,8 +4,9 @@ use warnings;
 use Test::More;
 plan tests => 7;
 
+use lib 't/lib';
 use HTTP::XSHeaders;
-use t::lib::Utils;
+use MyTestUtils;
 
 sub j { join('|', @_) }
 
@@ -34,25 +35,25 @@ is_deeply(
 );
 
 like(
-    t::lib::Utils::_try(sub { HTTP::XSHeaders::_header() }),
+    MyTestUtils::_try(sub { HTTP::XSHeaders::_header() }),
     qr/\QUsage: HTTP::XSHeaders::_header\E/,
     'HTTP::XSHeaders::_header() without args',
 );
 
 like(
-    t::lib::Utils::_try(sub { HTTP::XSHeaders::_header(undef) }),
+    MyTestUtils::_try(sub { HTTP::XSHeaders::_header(undef) }),
     qr/\Qis not an instance of HTTP::XSHeaders\E/,
     'HTTP::XSHeaders::_header() with undef',
 );
 
 like(
-    t::lib::Utils::_try(sub { $h->_header() }),
+    MyTestUtils::_try(sub { $h->_header() }),
     qr/\Q_header not called with one argument\E/,
     '_header() without args',
 );
 
 like(
-    t::lib::Utils::_try(sub { $h->_header(undef) }),
+    MyTestUtils::_try(sub { $h->_header(undef) }),
     qr/\Q_header not called with one string argument\E/,
     '_header() with undef',
 );

--- a/t/lib/MyTestUtils.pm
+++ b/t/lib/MyTestUtils.pm
@@ -1,4 +1,4 @@
-package t::lib::Utils;
+package MyTestUtils;
 use strict;
 use warnings;
 

--- a/t/validate_invocant.t
+++ b/t/validate_invocant.t
@@ -4,8 +4,9 @@ use warnings;
 use Test::More;
 plan tests => 44;
 
+use lib 't/lib';
 use HTTP::XSHeaders;
-use t::lib::Utils;
+use MyTestUtils;
 
 my $h = HTTP::XSHeaders->new;
 
@@ -87,13 +88,13 @@ EOS
 
 # test invalid call to scan
 like(
-    t::lib::Utils::_try(sub { $h->scan() }),
+    MyTestUtils::_try(sub { $h->scan() }),
     qr/Usage: HTTP::XSHeaders::scan/,
     'scan() without arguments',
 );
 
 like(
-    t::lib::Utils::_try(sub { $h->scan(undef) }),
+    MyTestUtils::_try(sub { $h->scan(undef) }),
     qr/Second argument must be a CODE reference/,
     'scan() without coderef',
 );
@@ -105,25 +106,25 @@ is(
 );
 
 like(
-    t::lib::Utils::_try(sub { HTTP::XSHeaders::init_header() }),
+    MyTestUtils::_try(sub { HTTP::XSHeaders::init_header() }),
     qr/Usage: HTTP::XSHeaders::init_header/,
     'HTTP::XSHeaders::init_header()'
     );
 
 like(
-    t::lib::Utils::_try(sub { $h->init_header() }),
+    MyTestUtils::_try(sub { $h->init_header() }),
     qr/init_header needs two arguments/,
     'init_header()'
 );
 
 like(
-    t::lib::Utils::_try(sub { $h->init_header(undef) }),
+    MyTestUtils::_try(sub { $h->init_header(undef) }),
     qr/init_header needs two arguments/,
     'init_header(undef)'
 );
 
 like(
-    t::lib::Utils::_try(sub { $h->init_header(undef, undef) }),
+    MyTestUtils::_try(sub { $h->init_header(undef, undef) }),
     qr/init_header not called with a first string argument/,
     'init_header(undef, undef)'
 );


### PR DESCRIPTION
Newer perls don't have the current directory on @INC.  Although
toolchain modules often work around this, they may not do so forever.
It also prevents running individual test scripts manually.

Fix this by moving the test helper module to a better name, and loading
it by adding t/lib to the library path rather than from the current
directory.